### PR TITLE
Linux compilation without Code::Blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 rom:
 	mkdir -p bin/Release
 	mkdir -p obj/Release
-	echo Wobble
+
 	sdasz80 -o ./obj/Release/crt0.rel crt0.s
 	sdcc --no-std-crt0 -mz80 --opt-code-size --code-loc 0xC100 --data-loc 0x1000 --verbose -c main.c -o obj/Release/main.rel
 	sdcc -o bin/Release/SDCC\ ROM.ihx --no-std-crt0 -mz80 --opt-code-size --code-loc 0xC100 --data-loc 0x1000 --verbose obj/Release/crt0.rel obj/Release/main.rel


### PR DESCRIPTION
This pull request adds a Makefile that compiles the ROM on a Linux system without having to use Code::Blocks.
